### PR TITLE
Compatibilidad para Spigot 1.21.1

### DIFF
--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -64,7 +64,7 @@
         <!-- Only include the most recent version implementation -->
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
-            <artifactId>images-v1_21_R4</artifactId>
+            <artifactId>images-v1_21_R1</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- apuntar el núcleo hacia `images-v1_21_R1`
- usar BuildTools con la versión `1.21.1` en el flujo de release

## Testing
- `wget -O /dev/null https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar`

------
https://chatgpt.com/codex/tasks/task_e_6862a849ea208328a5de54f4ef693b18