### PR TITLE
Compatibilidad para Spigot 1.21.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build Spigot 1.21.1
         run: |
           wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-          java -jar BuildTools.jar --rev 1.21.1
+          java -jar BuildTools.jar --rev 1.21.1 --compile craftbukkit --compile spigot --remapped
 
       - name: Build latest version
         run: mvn -pl Images-Core -am clean package -DskipTests

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -64,7 +64,7 @@
         <!-- Only include the most recent version implementation -->
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
-            <artifactId>images-v1_21_R4</artifactId>
+            <artifactId>images-v1_21_R1</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Compiling
 ---------
 
 1. Ensure that you have the project setup properly with Maven
-2. Compile from the parent project of Images that all modules are contained within
-3. Run `mvn clean package`
+2. Build the Spigot 1.21.1 dependencies using BuildTools:
+   `java -jar BuildTools.jar --rev 1.21.1 --compile craftbukkit --compile spigot --remapped`
+3. Compile from the parent project of Images that all modules are contained within
+4. Run `mvn clean package`
 
 Contributing
 ------------


### PR DESCRIPTION
## Summary
- apuntar el núcleo hacia `images-v1_21_R1`
- usar BuildTools con la versión `1.21.1` en el flujo de release
- ejecutar BuildTools con `--compile craftbukkit --compile spigot --remapped`
- documentar cómo construir dependencias 1.21.1

## Testing
- `mvn -pl Images-Core -am -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862a849ea208328a5de54f4ef693b18